### PR TITLE
Patch email templates

### DIFF
--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/common_approved_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/common_approved_body.txt
@@ -24,6 +24,6 @@ Specific access information is available at:
 
 https://confluence-vre.its.monash.edu.au/display/monarch/How+to+Access+MonARCH
 
-For MonARCH help, please mcc-help@monash.edu
+For MonARCH help, please email mcc-help@monash.edu
 
 {% include "karaage/emails/email_footer.txt" %}{% endautoescape %}

--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/common_approved_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/common_approved_body.txt
@@ -1,8 +1,22 @@
-{% autoescape off %}Hello {{ receiver.get_short_name }},
+{% autoescape off %}Hello {{ receiver.get_full_name }},
 
-We are pleased to advise that your application to use MonARCH has been approved. Your account is currently being prepared and will be ready to use within 30 minutes. 
+We are pleased to advise that your HPCID application has been approved. Your account is currently being provisioned and will be ready to use within 2 hours.
 
-Please find all relevant information on MonARCH at:
+MASSIVE 3 (M3) Users
+--------------------
+M3 documentation can be found at:
+
+http://docs.massive.org.au
+
+Specific access information is available at:
+
+http://docs.massive.org.au/M3/connecting-to-m3.html
+
+For M3 help, please email help@massive.org.au
+
+MonARCH Users
+-------------
+MonARCH documentation can be found at:
 
 https://confluence-vre.its.monash.edu.au/display/monarch/MonARCH+Home
 
@@ -10,6 +24,6 @@ Specific access information is available at:
 
 https://confluence-vre.its.monash.edu.au/display/monarch/How+to+Access+MonARCH
 
-For help, please contact: mcc-help@monash.edu
+For MonARCH help, please mcc-help@monash.edu
 
 {% include "karaage/emails/email_footer.txt" %}{% endautoescape %}

--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/common_declined_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/common_declined_body.txt
@@ -1,5 +1,4 @@
-{% autoescape off %}Hello {{ receiver.get_short_name }},
-
+{% autoescape off %}Hello {{ receiver.get_full_name }},
 
 Your {{ org_name }} application to {{ application.info }} has been declined.
 

--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/common_invite_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/common_invite_body.txt
@@ -1,4 +1,4 @@
-{% autoescape off %}{% if receiver.get_short_name %}Hello {{ receiver.get_short_name }},
+{% autoescape off %}{% if receiver.get_full_name %}Hello {{ receiver.get_full_name }},
 {% else %}Hello,
 {% endif %}
 

--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/common_request_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/common_request_body.txt
@@ -1,6 +1,5 @@
 {% autoescape off %}Hello {{ receiver.get_full_name }},
 
-
 {{ application.applicant }} is requesting to {{ application.info }}.
 
 This application is now waiting for {{ authorised_text }} to process the application.

--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/common_request_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/common_request_body.txt
@@ -1,4 +1,4 @@
-{% autoescape off %}Hello {{ receiver.get_short_name }},
+{% autoescape off %}Hello {{ receiver.get_full_name }},
 
 
 {{ application.applicant }} is requesting to {{ application.info }}.

--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/user_request_common_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/user_request_common_body.txt
@@ -1,7 +1,7 @@
-{% autoescape off %}Hello {{ receiver.get_short_name }},
+{% autoescape off %}Hello {{ receiver.get_full_name }},
 
-Thank you for your interest to {{ request_type }} project {{ project_name }}.
+Thank you for your expression of interest to {{ request_type }} the project "{{ project_name }}".
 
-Your request has been received and we will respond within two business days on its outcome.
+Your request has been received and we will notify you of the outcome within two business days.
 
 {% include "karaage/emails/email_footer.txt" %}{% endautoescape %}

--- a/karaage/plugins/kgapplications/templates/kgapplications/emails/user_request_monarch_body.txt
+++ b/karaage/plugins/kgapplications/templates/kgapplications/emails/user_request_monarch_body.txt
@@ -1,7 +1,7 @@
-{% autoescape off %}Hello {{ receiver.get_short_name }},
+{% autoescape off %}Hello {{ receiver.get_full_name }},
 
-Thank you for your interest to use MonARCH, the successor to the MCC.
+Thank you for your expression of interest to use MonARCH, the successor to the MCC.
 
-Your request has been received and we will respond within two business days on its outcome.
+Your request has been received and we will notify you of the outcome within two business days.
 
 {% include "karaage/emails/email_footer.txt" %}{% endautoescape %}

--- a/karaage/templates/karaage/emails/email_footer.txt
+++ b/karaage/templates/karaage/emails/email_footer.txt
@@ -1,3 +1,3 @@
 Kind regards,
 
-Them {{ org_name }} accounts team
+The {{ org_name }} accounts team

--- a/karaage/templates/karaage/emails/email_footer.txt
+++ b/karaage/templates/karaage/emails/email_footer.txt
@@ -1,3 +1,3 @@
-Thanks,
+Kind regards,
 
-{{ org_name }} accounts team
+Them {{ org_name }} accounts team


### PR DESCRIPTION
Adding M3 specific links (per Gin's instructions), and fixing short name issue that sends emails saying "Hello surname,"